### PR TITLE
Use https for scripts and stylesheets

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
   <head>
     
     <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
 
     <!-- jQuery UI CSS -->
-    <link rel="stylesheet" href="http://code.jquery.com/ui/1.11.0/themes/smoothness/jquery-ui.css">
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.11.0/themes/smoothness/jquery-ui.css">
 
     <!-- Custom CSS -->
     <link rel="stylesheet" href="css/css/styles.css">
@@ -19,14 +19,14 @@
         
 
     <!-- jQuery -->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-    <script src="http://code.jquery.com/ui/1.11.0/jquery-ui.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://code.jquery.com/ui/1.11.0/jquery-ui.js"></script>
     
     <!-- Bootstrap-->
-    <script src="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+    <script src="https://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 
     <!-- D3 -->
-    <script src="http://d3js.org/d3.v3.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
 
     <!-- Sylvester -->
     <script type="text/javascript" src="js/sylvester.js"></script>
@@ -41,7 +41,7 @@
     <script type="text/javascript" src="js/d3Parcoords.js"></script>
 
     <!-- Spin.js -->
-    <script type="text/javascript" src="http://fgnass.github.io/spin.js/spin.min.js"></script>
+    <script type="text/javascript" src="https://fgnass.github.io/spin.js/spin.min.js"></script>
 
     <!-- USV -->
     <script type="text/javascript" src="js/USV.js"></script>


### PR DESCRIPTION
When this tool is served over https Chrome (and probably othe browsers) refuses to load scripts from 'unauthenticated sources', i.e. <script src="http://..." ...>. This results in just a blank page.

Fetching scripts over https has no adverse effects when the tool is served over plain http.
